### PR TITLE
Revert python slim buster

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.2-slim-buster
+FROM python:3.9.1-slim-buster
 
 ENV APP_DIR=/opt/app
 


### PR DESCRIPTION
I reverted to 3.9.1-slim-buster and the `RemoteDisconnect` issue disappeared.  I think its best we lock to a stable version of this version that we know works.  Although, to be honest, the whole `RemoteDisconnect` issue is still sort of a mystery to me.

Happy to leave this as a draft so we can discuss more.