### PR TITLE
Add nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,6 @@ services:
       - database-data:/data/db
     networks:
       - nlpsandbox-internal
-    # ports:
-    #   - "${MONGO_PORT}:27017"
 
   data-node:
     image: nlpsandbox/data-node:1.2.1
@@ -36,15 +34,8 @@ services:
       - DB_DATABASE=${DB_DATABASE}
       - DB_USERNAME=${DB_USERNAME}
       - DB_PASSWORD=${DB_PASSWORD}
-    # healthcheck:
-    #   test: curl --fail http://localhost:8080/api/v1/healthCheck
-    #   interval: 10s
-    #   timeout: 5s
-    #   retries: 5
     networks:
       - nlpsandbox-internal
-    # ports:
-    #   - "${SERVER_PORT}:8080"
     depends_on:
       - db
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,10 @@ services:
       - MONGO_PASSWORD=${MONGO_PASSWORD}
     volumes:
       - database-data:/data/db
-    ports:
-      - "${MONGO_PORT}:27017"
+    networks:
+      - nlpsandbox-internal
+    # ports:
+    #   - "${MONGO_PORT}:27017"
 
   data-node:
     image: nlpsandbox/data-node:1.2.1
@@ -39,10 +41,37 @@ services:
     #   interval: 10s
     #   timeout: 5s
     #   retries: 5
-    ports:
-      - "${SERVER_PORT}:8080"
+    networks:
+      - nlpsandbox-internal
+    # ports:
+    #   - "${SERVER_PORT}:8080"
     depends_on:
       - db
 
+  data-node-nginx:
+    image: nginx:1.19.6-alpine
+    container_name: data-node-nginx
+    restart: always
+    environment:
+      - SERVER_HOST=data-node
+      - SERVER_PORT=${SERVER_PORT}
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/templates:/etc/nginx/templates:ro
+    networks:
+      - nlpsandbox
+      - nlpsandbox-internal
+    ports:
+      - "8080:80"
+    depends_on:
+      - data-node
+
 volumes:
     database-data:
+
+networks:
+  nlpsandbox:
+    name: nlpsandbox
+  nlpsandbox-internal:
+    name: nlpsandbox-internal
+    internal: true

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,8 @@
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+include conf.d/events.conf;
+include conf.d/http.conf;

--- a/nginx/templates/events.conf.template
+++ b/nginx/templates/events.conf.template
@@ -1,0 +1,3 @@
+events {
+    worker_connections 1024;
+}

--- a/nginx/templates/http.conf.template
+++ b/nginx/templates/http.conf.template
@@ -1,0 +1,29 @@
+http {
+    upstream server {
+        server ${SERVER_HOST}:${SERVER_PORT};
+        keepalive 15;
+    }
+
+    server {
+        listen 80;
+        server_name tool;
+
+        error_log   /var/log/nginx/tool.error.log;
+        access_log  /var/log/nginx/tool.access.log;
+
+        location / {
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header Host $http_host;
+
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+
+            proxy_set_header Connection "Keep-Alive";
+            proxy_set_header Proxy-Connection "Keep-Alive";
+
+            proxy_pass http://server;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #219 

Test:

- `docker compose up`
- Navigate to http://localhost:8080/api/v1/ui/

Motivations:

- More secure as the data node container no longer has access to internet (e.g. a malicious dependency could have uploaded data to a remote server).
  - While I trust our implementation of the data node to not upload data to a remote server, an external user may not trust our implementation.
- Consistent pattern by always having nginx in front of services. 